### PR TITLE
WEC-Sim Installation/activation/deactivation using Startup and Cleanup scripts

### DIFF
--- a/cleanup.m
+++ b/cleanup.m
@@ -1,0 +1,24 @@
+% First written by : Gordon G. Parker, Michigan Technological University
+% Modifed for WEC-Sim by: Sal Husain, sal.husain@nrel.gov
+% Last modified : June 9th, 2021
+
+% Root directory of this running .m file
+projectRootDir = fileparts(mfilename('fullpath'));
+
+% Remove project directories from path
+rmpath(fullfile(projectRootDir,genpath('examples')));
+rmpath(fullfile(projectRootDir,genpath('Sal')));
+rmpath(fullfile(projectRootDir,genpath('source')));
+rmpath(fullfile(projectRootDir,genpath('tests')));
+rmpath(fullfile(projectRootDir,genpath('tutorials')));
+% rmpath(fullfile(projectRootDir,genpath('models')));
+rmpath(fullfile(projectRootDir,'work'));
+% rmpath(fullfile(projectRootDir,genpath('scripts')));
+% rmpath(fullfile(projectRootDir,'code'));
+
+% Reset the loction of Simulink-generated files
+Simulink.fileGenControl('reset');
+
+% leave no trace...
+clear projectRootDir
+

--- a/startup.m
+++ b/startup.m
@@ -1,0 +1,23 @@
+% First written by : Gordon G. Parker, Michigan Technological University
+% Modifed for WEC-Sim by: Sal Husain, sal.husain@nrel.gov
+% Last modified : June 9th, 2021
+
+
+% Root directory of this running .m file
+projectRootDir = fileparts(mfilename('fullpath'));
+
+% Add project directories to path
+addpath(fullfile(projectRootDir,genpath('examples')),'-end');
+addpath(fullfile(projectRootDir,genpath('Sal')),'-end');
+addpath(fullfile(projectRootDir,genpath('source')),'-end');
+addpath(fullfile(projectRootDir,genpath('tests')),'-end');
+addpath(fullfile(projectRootDir,genpath('tutorials')),'-end');
+% addpath(fullfile(projectRootDir,genpath('models')),'-end');
+addpath(fullfile(projectRootDir,'work'),'-end');
+% addpath(fullfile(projectRootDir,genpath('scripts')),'-end');
+% % addpath(fullfile(projectRootDir,'code'),'-end');
+
+% Save Simulink-generated helper files to work
+Simulink.fileGenControl('set',...
+    'CacheFolder',fullfile(projectRootDir,'work'),...
+    'CodeGenFolder',fullfile(projectRootDir,'work'));


### PR DESCRIPTION
Hi All,

I have created two scripts, that can simplify the installation process,
[cleanup_m.txt](https://github.com/salhus/WEC-Sim/files/6626920/cleanup_m.txt)
[startup_m.txt](https://github.com/salhus/WEC-Sim/files/6626921/startup_m.txt)



startup.m : This scripts initiates the WEC-Sim environment and adds all necessary sub-folders on the MATLAB path. This script also sets simulink to put all the extra slrpj files in a 'work' folder.
cleanup.m : This script removes all the folders and sets the simulink back to default settings.
An empty folder titles 'work' needs to be created so that the startup.m script runs without errors.
The advantage of these two scripts is that it simplifies the installation process and the activation every time a user needs to use WEC-Sim, but then change the working folder to some other folder and do other work.

A new user will just need to download the wecsim folder from GitHub and run the startup script and not go through setting up the paths and MATLAB startup directory manually.

I am attaching the files here.

Cheers,
Sal